### PR TITLE
Rename "transshipment" to "cross docking"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Transload Landing Page
 
-A modern, responsive landing page for Transload - an intelligent forklift control system that optimizes forklift routes and streamlines transshipment warehouse operations through AI-powered optimization solutions.
+A modern, responsive landing page for Transload - an intelligent forklift control system that optimizes forklift routes and streamlines cross docking warehouse operations through AI-powered optimization solutions.
 
 ## 🚀 About the Project
 

--- a/app/components/Benefits.tsx
+++ b/app/components/Benefits.tsx
@@ -4,7 +4,7 @@ import { CheckCircle } from "lucide-react";
 
 const benefits = {
 	en: [
-		"Reduce operational costs from the first month, as fewer drivers are needed in the transshipment warehouse",
+		"Reduce operational costs from the first month, as fewer drivers are needed in the cross docking warehouse",
 		"Increase warehouse efficiency and throughput",
 		"Minimize forklift idle time and unnecessary movement",
 	],

--- a/app/components/GetInTouch.tsx
+++ b/app/components/GetInTouch.tsx
@@ -4,7 +4,7 @@ import { Mail, Calendar, Linkedin, Zap } from "lucide-react";
 
 const content = {
 	en: {
-		title: "Ready to Upgrade Your Transshipment Warehouse?",
+		title: "Ready to Upgrade Your Cross Docking Warehouse?",
 		description: "Get in touch with us.",
 		meeting: "Schedule a Meeting",
 		meetingUrl: "https://cal.com/jago-wahl/",

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -4,7 +4,7 @@ import { ArrowDown, Zap } from "lucide-react";
 export default function Hero({ language }: { language: "en" | "de" }) {
 	const content = {
 		en: {
-			title: "Forklift Control System for Transshipment Warehouses",
+			title: "Forklift Control System for Cross Docking Warehouses",
 			subtitle: "Revolutionize Your Warehouse Operations",
 			description: "Fewer Empty Runs. Lower Costs. Higher Productivity.",
 		},

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,26 +6,47 @@ export const metadata = {
 	themeColor: "#0C3A5F",
 	keywords: [
 		// Deutsch
-		"Staplerleitsystem", "Umschlaglager", "Leerfahrten", "Kosten sparen", "Intralogistik", "Logistiksoftware",
-		"Lagerverwaltungssystem", "Flurfördermittel", "Disposition Stapler", "Effizienzsteigerung Lager",
-		"Automatisierung Umschlaglager", "KI in der Intralogistik", "Logistik Digitalisierung", "Start-Up", "Startup",
-	  
+		"Staplerleitsystem",
+		"Umschlaglager",
+		"Leerfahrten",
+		"Kosten sparen",
+		"Intralogistik",
+		"Logistiksoftware",
+		"Lagerverwaltungssystem",
+		"Flurfördermittel",
+		"Disposition Stapler",
+		"Effizienzsteigerung Lager",
+		"Automatisierung Umschlaglager",
+		"KI in der Intralogistik",
+		"Logistik Digitalisierung",
+		"Start-Up",
+		"Startup",
+
 		// Englisch
-		"Intralogistics", "Transshipment Warehouse", "Forklift", "Pallet Truck", "Route Optimization", "Cost Savings",
-		"Forklift Guidance System", "Warehouse Control System", "Fleet Management", "Material Flow Optimization",
-		"Cross Docking Software", "Smart Warehouse", "AI Logistics"
-	  ],
+		"Intralogistics",
+		"Transshipment Warehouse",
+		"Forklift",
+		"Pallet Truck",
+		"Route Optimization",
+		"Cost Savings",
+		"Forklift Guidance System",
+		"Warehouse Control System",
+		"Fleet Management",
+		"Material Flow Optimization",
+		"Cross Docking Software",
+		"Smart Warehouse",
+		"AI Logistics",
+	],
 	openGraph: {
 		type: "website",
 		url: "https://www.trans-load.de",
 		title: "transload - Staplerleitsystem für Umschlaglager",
 		description: "Weniger Leerfahrten. Geringere Kosten. Höhere Produktivität.",
-		images: './open_graph.jpg',
+		images: "./open_graph.jpg",
 	},
 	icons: {
-		icon: './favicon.png',
-	  },
-	
+		icon: "./favicon.png",
+	},
 };
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,8 @@ export const metadata = {
 		// Englisch
 		"Intralogistics",
 		"Transshipment Warehouse",
+		"Cross Docking Warehouse",
+		"Cross Docking",
 		"Forklift",
 		"Pallet Truck",
 		"Route Optimization",


### PR DESCRIPTION
Because we found out the the proper translation for "Umschlaglager" is "Cross Docking Warehouse", we need to adapt this in our website